### PR TITLE
Configure backend port via env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+API_URL=http://localhost:8080

--- a/scripts/generate-env.js
+++ b/scripts/generate-env.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+const dotenv = require('dotenv');
+
+const envPath = path.resolve(__dirname, '..', '.env');
+const result = dotenv.config({ path: envPath });
+const apiUrl = (result.parsed && result.parsed.API_URL) || 'http://localhost:8080';
+
+const content = `window['env'] = window['env'] || {};
+window['env']['API_URL'] = '${apiUrl}';
+`;
+
+const outputPath = path.resolve(__dirname, '..', 'src', 'assets', 'env.js');
+fs.writeFileSync(outputPath, content);
+

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -1,0 +1,2 @@
+window['env'] = window['env'] || {};
+window['env']['API_URL'] = 'http://localhost:8080';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiUrl: (window as any)?.env?.API_URL || 'http://localhost:8080'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: (window as any)?.env?.API_URL || 'http://localhost:8080'
 };
 
 /*

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <script src="assets/env.js"></script>
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
## Summary
- load env.js at runtime and expose API_URL variable
- add generate-env script to build env.js from `.env`
- set API_URL to `http://localhost:8080`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a0b2233b083298fa8994dde3aa24d